### PR TITLE
fix: Add validation for missing items in sales order sync

### DIFF
--- a/woocommerce_fusion/tasks/sync_sales_orders.py
+++ b/woocommerce_fusion/tasks/sync_sales_orders.py
@@ -979,6 +979,13 @@ class SynchroniseSalesOrder(SynchroniseWooCommerce):
 
 				found_item = frappe.get_doc("Item", item_codes[0].parent) if item_codes else None
 
+			if not found_item:
+				raise ValueError(
+					_("Item not found for WooCommerce product ID {0} on server '{1}'").format(
+						woocomm_item_id, new_sales_order.woocommerce_server
+					)
+				)
+
 			# If we are applying a Sales Taxes and Charges Template (as opposed to Actual Tax), then we need to
 			# determine if the item price should include tax or not
 			if wc_server.enable_tax_lines_sync and not wc_server.use_actual_tax_type:


### PR DESCRIPTION
## Summary
Add explicit error handling when WooCommerce product item is not found in ERPNext during sales order synchronization.

## Problem
Previously, if an item was not found in ERPNext (when `item_codes` is empty), the code would fail with an `AttributeError: 'NoneType' object has no attribute 'name'` when trying to access `found_item.name` at line 997.

## Solution
This PR adds a validation check immediately after attempting to find the item. If `found_item` is `None`, it raises a `ValueError` with a clear, localized error message that indicates:
- The specific WooCommerce product ID that couldn't be found
- The WooCommerce server where the lookup failed

## Changes
- Added `if not found_item:` validation block after line 980
- Raises `ValueError` with helpful error message using Frappe's translation function
- Prevents downstream `AttributeError` and improves debugging experience

## Benefits
1. **Better Error Messages**: Clear indication of which product and server are causing issues
2. **Easier Debugging**: Users can immediately identify the missing product ID
3. **Consistency**: Aligns with existing error handling patterns in the codebase
4. **Internationalization**: Uses `_()` function for translation support

## Test Plan
This change can be tested by:
1. Creating a WooCommerce order with a product ID that doesn't exist in ERPNext
2. Attempting to sync the order
3. Verifying that a clear error message is shown instead of an AttributeError

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sales order sync reliability by failing fast when a product cannot be matched, rather than silently proceeding.
  * Clearer error messages now identify the specific product and source, enabling faster diagnosis and resolution.
  * Prevents incomplete or incorrect order creation and reduces data inconsistencies during synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->